### PR TITLE
Refer to Promise functions via the Promise object in FFI

### DIFF
--- a/src/Web/Promise/Internal.js
+++ b/src/Web/Promise/Internal.js
@@ -14,7 +14,18 @@ exports.finally = function(k, p) {
   return p.finally(k);
 };
 
-exports.resolve = Promise.resolve;
-exports.reject = Promise.reject;
-exports.all = Promise.all;
-exports.race = Promise.race;
+exports.resolve = function(a) {
+  return Promise.resolve(a);
+};
+
+exports.reject = function(a) {
+  return Promise.reject(a);
+};
+
+exports.all = function(a) {
+  return Promise.all(a);
+};
+
+exports.race = function(a) {
+  return Promise.race(a);
+};


### PR DESCRIPTION
Use the functions defined in `Web.Promise.Internal` via the FFI (resolve, etc.) on master and you'll see an error like:

```
UnhandledPromiseRejectionWarning: TypeError: #<Object> is not a constructor
  at Object.resolve (<anonymous>)
  at ...
```

@natefaubion did a brief console session and noticed:

```
>> var a = Promise.resolve

>> a
function resolve()

>> a(12)
TypeError: Receiver of Promise.resolve call is not a non-null object
```

and

```
>> var b = { a: Promise.resolve }

>> b.a(12)
TypeError: b is not a constructor
```

The adjusted exports in the FFI file avoid these issues.