### PR TITLE
Add roles declarations to allow safe coercions

### DIFF
--- a/src/Web/Promise/Internal.purs
+++ b/src/Web/Promise/Internal.purs
@@ -8,6 +8,8 @@ import Web.Promise.Rejection (Rejection)
 
 foreign import data Promise :: Type -> Type
 
+type role Promise representational
+
 foreign import new :: forall a. EffectFn1 (EffectFn2 (EffectFn1 a Unit) (EffectFn1 Rejection Unit) Unit) (Promise a)
 
 foreign import then_ :: forall a b. EffectFn2 (EffectFn1 a (Promise b)) (Promise a) (Promise b)


### PR DESCRIPTION
This allows terms of type `Promise a` to be coerced to type `Promise b` when `Coercible a b` holds, hence allowing the zero cost `coerce` instead of `map wrap` and `map unwrap` to introduce and eliminate newtypes under promises for instance.