### PR TITLE
Migrate to GitHub Actions

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,29 @@
+{
+  "parserOptions": {
+    "ecmaVersion": 5
+  },
+  "extends": "eslint:recommended",
+  "env": {
+    "commonjs": true,
+    "browser": true
+  },
+  "rules": {
+    "strict": [2, "global"],
+    "block-scoped-var": 2,
+    "consistent-return": 2,
+    "eqeqeq": [2, "smart"],
+    "guard-for-in": 2,
+    "no-caller": 2,
+    "no-extend-native": 2,
+    "no-loop-func": 2,
+    "no-new": 2,
+    "no-param-reassign": 2,
+    "no-return-assign": 2,
+    "no-unused-expressions": 2,
+    "no-use-before-define": 2,
+    "radix": [2, "always"],
+    "indent": [2, 2],
+    "quotes": [2, "double"],
+    "semi": [2, "always"]
+  }
+}

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,6 +7,9 @@
     "commonjs": true,
     "browser": true
   },
+  "globals": {
+    "Promise": "readonly"
+  },
   "rules": {
     "strict": [2, "global"],
     "block-scoped-var": 2,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: CI
 
-on: push
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on: push
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: purescript-contrib/setup-purescript@main
+
+      - uses: actions/setup-node@v1
+        with:
+          node-version: "10"
+
+      - name: Install dependencies
+        run: |
+          npm install -g bower
+          npm install
+          bower install --production
+
+      - name: Build source
+        run: npm run-script build
+
+      - name: Run tests
+        run: |
+          bower install
+          npm run-script test --if-present

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,9 @@
+/.*
+!/.gitignore
+!/.eslintrc.json
+!/.github/
+package-lock.json
 /bower_components/
 /node_modules/
-/.pulp-cache/
 /output/
 /generated-docs/
-/.psc-package/
-/.psc*
-/.purs*
-/.psa*

--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
 # purescript-web-promise
+
+[![Latest release](http://img.shields.io/github/release/purescript-web/purescript-web-promise.svg)](https://github.com/purescript-web/purescript-web-promise/releases)
+[![Build status](https://github.com/purescript/purescript-web-promise/workflows/CI/badge.svg?branch=master)](https://github.com/purescript/purescript-web-promise/actions?query=workflow%3ACI+branch%3Amaster)
+[![Pursuit](https://pursuit.purescript.org/packages/purescript-web-promise/badge)](https://pursuit.purescript.org/packages/purescript-web-promise)
+
+Types and low-level implementations for JavaScript Promises.
+
+## Installation
+
+```
+spago install web-promise
+```
+
+## Documentation
+
+Module documentation is [published on Pursuit](http://pursuit.purescript.org/packages/purescript-web-promise).
+

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # purescript-web-promise
 
 [![Latest release](http://img.shields.io/github/release/purescript-web/purescript-web-promise.svg)](https://github.com/purescript-web/purescript-web-promise/releases)
-[![Build status](https://github.com/purescript/purescript-web-promise/workflows/CI/badge.svg?branch=master)](https://github.com/purescript/purescript-web-promise/actions?query=workflow%3ACI+branch%3Amaster)
+[![Build status](https://github.com/purescript-web/purescript-web-promise/workflows/CI/badge.svg?branch=master)](https://github.com/purescript-web/purescript-web-promise/actions?query=workflow%3ACI+branch%3Amaster)
 [![Pursuit](https://pursuit.purescript.org/packages/purescript-web-promise/badge)](https://pursuit.purescript.org/packages/purescript-web-promise)
 
 Types and low-level implementations for JavaScript Promises.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "private": true,
+  "scripts": {
+    "clean": "rimraf output && rimraf .pulp-cache",
+    "build": "eslint src && pulp build -- --censor-lib --strict"
+  },
+  "devDependencies": {
+    "eslint": "^7.15.0",
+    "pulp": "^15.0.0",
+    "purescript-psa": "^0.8.0",
+    "rimraf": "^3.0.2"
+  }
+}

--- a/src/Web/Promise/Internal.js
+++ b/src/Web/Promise/Internal.js
@@ -1,3 +1,5 @@
+"use strict";
+
 exports.new = function(k) {
   return new Promise(k);
 };

--- a/src/Web/Promise/Rejection.js
+++ b/src/Web/Promise/Rejection.js
@@ -1,3 +1,5 @@
+"use strict";
+
 exports.fromError = function(a) {
   return a;
 };


### PR DESCRIPTION
This PR migrates web-promise to use GitHub Actions instead of Travis for CI, as tracked for all core libraries in https://github.com/purescript/purescript/issues/3962. It also updates the installation instructions to refer to [Spago](https://github.com/purescript/spago) instead of Bower and adds a Pursuit link.