### PR TITLE
Add functions to convert to / from a Promise to a LazyPromise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Notable changes to this project are documented in this file. The format is based
 Breaking changes:
 
 New features:
+- Added `toPromise` and `fromPromise` helper functions to the `LazyPromise` module for convenient transformations between the `Promise` and `LazyPromise` types (#12 by @thomashoneyman)
 
 Bugfixes:
 


### PR DESCRIPTION
**Description of the change**

It can be useful to convert a `Promise` into a `LazyPromise` or vice versa -- for example, several other libraries like `web-fetch` can create `Promise` values, but to be inserted in a chain of binds with `LazyPromise` values you'll need to convert it first. This PR adds two helper functions for this purpose.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- ~Linked any existing issues or proposals that this pull request should close~
- ~Updated or added relevant documentation~
- [ ] Added a test for the contribution (if applicable)
