### PR TITLE
Then or catch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ Bugfixes:
 
 Other improvements:
 
+## [v3.1.0](https://github.com/purescript-web/purescript-web-promise/releases/tag/v3.0.0) - 2022-07-30
+
+New features:
+- Added `thenOrCatch` (#16 by @garyb)
+
 ## [v3.0.0](https://github.com/purescript-web/purescript-web-promise/releases/tag/v3.0.0) - 2022-04-27
 
 Breaking changes:

--- a/src/Web/Promise.purs
+++ b/src/Web/Promise.purs
@@ -7,7 +7,7 @@ module Web.Promise
 import Prelude
 
 import Effect (Effect)
-import Effect.Uncurried (mkEffectFn1, mkEffectFn2, runEffectFn1, runEffectFn2)
+import Effect.Uncurried (mkEffectFn1, mkEffectFn2, runEffectFn1, runEffectFn2, runEffectFn3)
 import Web.Promise.Internal (Promise, reject)
 import Web.Promise.Internal as P
 import Web.Promise.Rejection (Rejection)
@@ -26,6 +26,15 @@ new k = runEffectFn1 P.new $ mkEffectFn2 \onResolve onReject ->
 
 then_ :: forall a b c. Flatten b c => (a -> Effect (Promise b)) -> Promise a -> Effect (Promise c)
 then_ k p = runEffectFn2 P.then_ (mkEffectFn1 k) p
+
+thenOrCatch
+  :: forall a b c
+  . Flatten b c
+  => (a -> Effect (Promise b))
+  -> (Rejection -> Effect (Promise b))
+  -> Promise a
+  -> Effect (Promise c)
+thenOrCatch k c p = runEffectFn3 P.thenOrCatch (mkEffectFn1 k) (mkEffectFn1 c) p
 
 catch :: forall a b. (Rejection -> Effect (Promise b)) -> Promise a -> Effect (Promise b)
 catch k p = runEffectFn2 P.catch (mkEffectFn1 k) p

--- a/src/Web/Promise/Internal.js
+++ b/src/Web/Promise/Internal.js
@@ -7,6 +7,10 @@ export function then_(k, p) {
   return p.then(k);
 }
 
+export function thenOrCatch(k, c, p) {
+  return p.then(k, c);
+}
+
 const catchImpl = function (k, p) {
   return p.catch(k);
 };

--- a/src/Web/Promise/Internal.purs
+++ b/src/Web/Promise/Internal.purs
@@ -3,7 +3,7 @@ module Web.Promise.Internal where
 import Prelude
 
 import Effect (Effect)
-import Effect.Uncurried (EffectFn1, EffectFn2)
+import Effect.Uncurried (EffectFn1, EffectFn2, EffectFn3)
 import Web.Promise.Rejection (Rejection)
 
 foreign import data Promise :: Type -> Type
@@ -13,6 +13,8 @@ type role Promise representational
 foreign import new :: forall a b. EffectFn1 (EffectFn2 (EffectFn1 a Unit) (EffectFn1 Rejection Unit) Unit) (Promise b)
 
 foreign import then_ :: forall a b c. EffectFn2 (EffectFn1 a (Promise b)) (Promise a) (Promise c)
+
+foreign import thenOrCatch :: forall a b c. EffectFn3 (EffectFn1 a (Promise b)) (EffectFn1 Rejection (Promise b)) (Promise a) (Promise c)
 
 foreign import catch :: forall a b. EffectFn2 (EffectFn1 Rejection (Promise b)) (Promise a) (Promise b)
 


### PR DESCRIPTION
**Description of the change**

Add `thenOrCatch f g p`, equivalent to `p.then(f, g)`. Without being able to add both callback and error handler at the same step it's difficult (maybe impossible?) to handle some cases with exactly the desired semantics.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
